### PR TITLE
Linting, formatting, misspelling; related goreportcard output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,17 @@
 .PHONY: all
 all: fmt lint vet test
 
+.PHONY: tools
+tools:
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.40.0
+
 .PHONY: fmt
 fmt:
 	go fmt ./...
 
 .PHONY: lint
 lint:
-	staticcheck
+	golangci-lint run ./...	
 
 .PHONY: test
 test:

--- a/accounting_client.go
+++ b/accounting_client.go
@@ -19,7 +19,7 @@ type AccountingClient interface {
 	ListAccountingUsers(ctx context.Context, input *ListAccountingUsersInput) (*ListAccountingUsersOutput, error)
 	// ListProjects will list your projects
 	ListProjects(ctx context.Context, input *ListProjectsInput) (*ListProjectsOutput, error)
-	// GetProjectDetails will read the deatils about a project
+	// GetProjectDetails will read the details about a project
 	GetProjectDetails(ctx context.Context, input *GetProjectDetailsInput) (*GetProjectDetailsOutput, error)
 }
 

--- a/accounting_client_fake_test.go
+++ b/accounting_client_fake_test.go
@@ -1,3 +1,4 @@
+// nolint:errcheck
 package modzy
 
 import (

--- a/accounting_client_test.go
+++ b/accounting_client_test.go
@@ -1,3 +1,4 @@
+// nolint:errcheck
 package modzy
 
 import (

--- a/dashboard_client_fake_test.go
+++ b/dashboard_client_fake_test.go
@@ -1,3 +1,4 @@
+// nolint:errcheck
 package modzy
 
 import (

--- a/dashboard_client_test.go
+++ b/dashboard_client_test.go
@@ -1,3 +1,4 @@
+// nolint:errcheck
 package modzy
 
 import (

--- a/dashboard_params.go
+++ b/dashboard_params.go
@@ -26,7 +26,7 @@ type GetAlertsOutput struct {
 	Alerts []AlertSummary `json:"alerts"`
 }
 
-// GetAlertsDetailsInput -
+// GetAlertDetailsInput -
 type GetAlertDetailsInput struct {
 	Type AlertType `json:"type"`
 }
@@ -37,6 +37,7 @@ type GetAlertDetailsOutput struct {
 	Entities []string  `json:"entities"`
 }
 
+// GetDataProcessedInput -
 // The default and minimum accepted time between BtartDate and EndDate is 7 days.
 // If only one date is provided the API matches it with a 7 day range.
 type GetDataProcessedInput struct {
@@ -53,6 +54,7 @@ type GetDataProcessedOutput struct {
 	Recent  []model.DataProcessingRecent `json:"recent"`
 }
 
+// GetPredictionsMadeInput -
 // The default and minimum accepted time between BtartDate and EndDate is 7 days.
 // If only one date is provided the API matches it with a 7 day range.
 type GetPredictionsMadeInput struct {

--- a/dashboard_params.go
+++ b/dashboard_params.go
@@ -100,27 +100,27 @@ type GetActiveModelsOutput struct {
 type PrometheusMetricType string
 
 const (
-	// The number of cores requested by a container
+	// PrometheusMetricTypeCPURequest - The number of cores requested by a container
 	PrometheusMetricTypeCPURequest PrometheusMetricType = "cpu-requested"
-	// The cluster’s total number of available CPU cores.
+	// PrometheusMetricTypeCPUAvailable - The cluster’s total number of available CPU cores.
 	PrometheusMetricTypeCPUAvailable PrometheusMetricType = "cpu-available"
-	// The total amount of “system” time + the total amount of “user” time
+	// PrometheusMetricTypeCPUUsed - The total amount of “system” time + the total amount of “user” time
 	PrometheusMetricTypeCPUUsed PrometheusMetricType = "cpu-used"
-	// The number of memory bytes requested by a container
+	// PrometheusMetricTypeMemoryRequested - The number of memory bytes requested by a container
 	PrometheusMetricTypeMemoryRequested PrometheusMetricType = "memory-requested"
-	//  A node’s total allocatable memory bytes
+	// PrometheusMetricTypeMemoryAvailable - A node’s total allocatable memory bytes
 	PrometheusMetricTypeMemoryAvailable PrometheusMetricType = "memory-available"
-	// The current memory usage in bytes, it includes all memory regardless of when it was accessed
+	// PrometheusMetricTypeMemoryUsed - The current memory usage in bytes, it includes all memory regardless of when it was accessed
 	PrometheusMetricTypeMemoryUsed PrometheusMetricType = "memory-used"
-	// cpu-used / cpu-available
+	// PrometheusMetricTypeCPUOverallUsage - cpu-used / cpu-available
 	PrometheusMetricTypeCPUOverallUsage PrometheusMetricType = "cpu-overall-usage"
-	// memory-used / memory-available
+	// PrometheusMetricTypeMemoryOverallUsage - memory-used / memory-available
 	PrometheusMetricTypeMemoryOverallUsage PrometheusMetricType = "memory-overall-usage"
-	// cpu-requested / cpu-available
+	// PrometheusMetricTypeCPUCurrentUsage - cpu-requested / cpu-available
 	PrometheusMetricTypeCPUCurrentUsage PrometheusMetricType = "cpu-current-usage"
 )
 
-// The default and minimum accepted time between startDate and endDate is 7 days.
+// GetPrometheusMetricInput - The default and minimum accepted time between startDate and endDate is 7 days.
 type GetPrometheusMetricInput struct {
 	BeginDate model.ModzyDate
 	EndDate   model.ModzyDate

--- a/internal/testing/main.go
+++ b/internal/testing/main.go
@@ -1,4 +1,5 @@
-// This package provides code examples that utilize the Modzy sdk.
+// main package provides code examples that utilize the Modzy sdk.
+// nolint
 package main
 
 import (
@@ -253,25 +254,26 @@ func afterSubmit(client modzy.Client, cancel bool, job modzy.JobActions) {
 		}
 		logrus.Infof("Job canceled: %s, %d", cancelOut.Details.Status, cancelOut.Details.HoursDeleteInput)
 		return
-	} else {
-		logrus.Info("Will wait until job completes")
-		jobDetails, err := job.WaitForCompletion(ctx, time.Second*5)
-		if err != nil {
-			logrus.WithError(err).Fatalf("Failed to wait for job completion")
-			return
-		}
-		logrus.Infof("Job completed: %s -> %s", jobDetails.Details.JobIdentifier, jobDetails.Details.Status)
-		jobResults, err := job.GetResults(ctx)
-		if err != nil {
-			logrus.WithError(err).Fatalf("Failed to get job results")
-			return
-		}
-		logrus.Infof("Job results: %s -> %d results", jobResults.Results.JobIdentifier, jobResults.Results.Total)
-
-		if len(jobResults.Results.Failures) > 0 {
-			logrus.Warnf("Job had failures: %+v", jobResults.Results.Failures)
-		}
 	}
+
+	logrus.Info("Will wait until job completes")
+	jobDetails, err := job.WaitForCompletion(ctx, time.Second*5)
+	if err != nil {
+		logrus.WithError(err).Fatalf("Failed to wait for job completion")
+		return
+	}
+	logrus.Infof("Job completed: %s -> %s", jobDetails.Details.JobIdentifier, jobDetails.Details.Status)
+	jobResults, err := job.GetResults(ctx)
+	if err != nil {
+		logrus.WithError(err).Fatalf("Failed to get job results")
+		return
+	}
+	logrus.Infof("Job results: %s -> %d results", jobResults.Results.JobIdentifier, jobResults.Results.Total)
+
+	if len(jobResults.Results.Failures) > 0 {
+		logrus.Warnf("Job had failures: %+v", jobResults.Results.Failures)
+	}
+
 }
 
 func describeJob(client modzy.Client, jobIdentifier string) {

--- a/internal/testing/main.go
+++ b/internal/testing/main.go
@@ -90,7 +90,7 @@ func errorChecking() {
 		if errors.Cause(err) == modzy.ErrUnauthorized {
 			logrus.WithError(err).Warnf("No authentication mechanism was provided")
 		} else {
-			logrus.WithError(err).Warnf("An unexpected error occured")
+			logrus.WithError(err).Warnf("An unexpected error occurred")
 		}
 
 	} else {

--- a/jobs_client.go
+++ b/jobs_client.go
@@ -1,4 +1,3 @@
-// nolint:errcheck
 package modzy
 
 import (
@@ -15,7 +14,7 @@ import (
 )
 
 type JobsClient interface {
-	// GetJobDetails will get the deatils of a job
+	// GetJobDetails will get the details of a job
 	GetJobDetails(ctx context.Context, input *GetJobDetailsInput) (*GetJobDetailsOutput, error)
 	// ListJobsHistory will list job history.  This supports paging, filtering and sorting.
 	ListJobsHistory(ctx context.Context, input *ListJobsHistoryInput) (*ListJobsHistoryOutput, error)
@@ -191,12 +190,12 @@ func (c *standardJobsClient) SubmitJobFile(ctx context.Context, input *SubmitJob
 		// uploading the inputs failed, close the job
 		_, _ = jobActions.Cancel(ctx)
 		return nil, errors.WithMessage(chunkErr, "job canceled due to failure to upload data")
-	} else {
-		// close the job since everything is posted
-		closeURL := fmt.Sprintf("/api/jobs/%s/close", response.JobIdentifier)
-		if _, err := c.baseClient.requestor.Post(ctx, closeURL, nil, nil); err != nil {
-			return nil, errors.WithMessage(err, "failed to close open job after successfully uploading inputs")
-		}
+	}
+
+	// close the job since everything is posted
+	closeURL := fmt.Sprintf("/api/jobs/%s/close", response.JobIdentifier)
+	if _, err := c.baseClient.requestor.Post(ctx, closeURL, nil, nil); err != nil {
+		return nil, errors.WithMessage(err, "failed to close open job after successfully uploading inputs")
 	}
 
 	return &SubmitJobFileOutput{

--- a/jobs_client.go
+++ b/jobs_client.go
@@ -14,7 +14,7 @@ import (
 )
 
 type JobsClient interface {
-	// GetJobDetails will get the deatils of a job
+	// GetJobDetails will get the details of a job
 	GetJobDetails(ctx context.Context, input *GetJobDetailsInput) (*GetJobDetailsOutput, error)
 	// ListJobsHistory will list job history.  This supports paging, filtering and sorting.
 	ListJobsHistory(ctx context.Context, input *ListJobsHistoryInput) (*ListJobsHistoryOutput, error)

--- a/jobs_client.go
+++ b/jobs_client.go
@@ -1,3 +1,4 @@
+// nolint:errcheck
 package modzy
 
 import (
@@ -14,7 +15,7 @@ import (
 )
 
 type JobsClient interface {
-	// GetJobDetails will get the details of a job
+	// GetJobDetails will get the deatils of a job
 	GetJobDetails(ctx context.Context, input *GetJobDetailsInput) (*GetJobDetailsOutput, error)
 	// ListJobsHistory will list job history.  This supports paging, filtering and sorting.
 	ListJobsHistory(ctx context.Context, input *ListJobsHistoryInput) (*ListJobsHistoryOutput, error)

--- a/jobs_client_fake_test.go
+++ b/jobs_client_fake_test.go
@@ -1,3 +1,4 @@
+// nolint:errcheck
 package modzy
 
 import (

--- a/jobs_client_test.go
+++ b/jobs_client_test.go
@@ -1,3 +1,4 @@
+// nolint:errcheck
 package modzy
 
 import (

--- a/jobs_params.go
+++ b/jobs_params.go
@@ -34,7 +34,7 @@ const (
 	ListJobsHistoryFilterFieldAccessKey ListJobsHistoryFilterField = "accessKey" // I see "prefix" in the docs -- what does that mean?
 )
 
-// ListJobsHistoryFilterField are known field names that can be used when sorting the jobs history
+// ListJobsHistorySortField are known field names that can be used when sorting the jobs history
 type ListJobsHistorySortField string
 
 const (

--- a/model/accounting.go
+++ b/model/accounting.go
@@ -30,7 +30,7 @@ type AccountingProject struct {
 	Status      string      `json:"status"`
 	Visibility  string      `json:"visibility"`
 	AccessKeys  []AccessKey `json:"accessKeys"`
-	User        UserSummary `json"user"`
+	User        UserSummary `json:"user"`
 	CreatedAt   ModzyTime   `json:"createdAt"`
 	UpdatedAt   ModzyTime   `json:"updatedAt"`
 }

--- a/model/job.go
+++ b/model/job.go
@@ -1,4 +1,4 @@
-// model package contains types as defined by the http api.
+// Package model contains types as defined by the http api.
 package model
 
 type ModelIdentifier struct {

--- a/model/jobresult.go
+++ b/model/jobresult.go
@@ -3,6 +3,7 @@ package model
 import (
 	"encoding/json"
 
+	"github.com/modzy/sdk-go/internal/impossible"
 	"github.com/pkg/errors"
 )
 
@@ -46,7 +47,7 @@ type JobResult struct {
 
 var _ json.Unmarshaler = &JobResult{}
 
-// Custom unmarshal in order to fill in ResultData with extra fields
+// UnmarshalJSON custom unmarshal in order to fill in ResultData with extra fields
 func (j *JobResult) UnmarshalJSON(b []byte) error {
 	// make a junk type so that we don't recurse into this unmarshal
 	type innerJobResult JobResult
@@ -59,8 +60,9 @@ func (j *JobResult) UnmarshalJSON(b []byte) error {
 
 	// get the extra fields
 	extra := make(map[string]interface{})
+
 	// I cannot think of a way this could error after the previous marshal passes...
-	json.Unmarshal(b, &extra)
+	impossible.HandleError(json.Unmarshal(b, &extra))
 
 	// do not repeat the known fields within the extras
 	for _, f := range []string{

--- a/models_client_fake_test.go
+++ b/models_client_fake_test.go
@@ -1,3 +1,4 @@
+// nolint:errcheck
 package modzy
 
 import (

--- a/models_client_test.go
+++ b/models_client_test.go
@@ -1,3 +1,4 @@
+// nolint:errcheck
 package modzy
 
 import (

--- a/overview.go
+++ b/overview.go
@@ -1,4 +1,4 @@
-// This package provides an SDK to easily access the modzy http API.
+// Package modzy provides an SDK to easily access the modzy http API.
 //
 // To use this SDK you need to create a modzy Client and then call any useful functions.  For example, if you need to get details about a model:
 // 	client := modzy.NewClient("https://your-base-url.example.com").WithAPIKey("your-api-key")

--- a/pagination.go
+++ b/pagination.go
@@ -53,7 +53,7 @@ func (p PagingInput) WithFilterAnd(field string, values ...string) PagingInput {
 	return p
 }
 
-// WithFilterAnd will create a paging filter that will filter for any value provided
+// WithFilterOr will create a paging filter that will filter for any value provided
 func (p PagingInput) WithFilterOr(field string, values ...string) PagingInput {
 	p.Filters = append(p.Filters, Filter{
 		Type:   FilterTypeOr,

--- a/pagingation_test.go
+++ b/pagingation_test.go
@@ -45,7 +45,7 @@ func TestPagingChain(t *testing.T) {
 		t.Errorf("Page not nexted properly, got %d:", next.Page)
 	}
 
-	// bot this and the next should be the same in fitlers and sorting
+	// bot this and the next should be the same in filters and sorting
 	for _, gotPaging := range []PagingInput{paging, paging.Next()} {
 		if gotPaging.PerPage != 20 {
 			t.Errorf("PerPage not set")

--- a/requestor_test.go
+++ b/requestor_test.go
@@ -1,3 +1,4 @@
+// nolint:errcheck
 package modzy
 
 import (

--- a/resources_client_fake_test.go
+++ b/resources_client_fake_test.go
@@ -1,3 +1,4 @@
+// nolint:errcheck
 package modzy
 
 import (

--- a/resources_client_test.go
+++ b/resources_client_test.go
@@ -1,3 +1,4 @@
+// nolint:errcheck
 package modzy
 
 import (

--- a/samples/aws_input/main.go
+++ b/samples/aws_input/main.go
@@ -81,7 +81,7 @@ func main() {
 	// With the info about the model (identifier) and the model version (version string, input/output keys), you are ready to
 	// submit the job. Just prepare the S3InputItem map:
 	mapSource := map[string]modzy.S3InputItem{
-		"source-key": modzy.S3InputItem{
+		"source-key": {
 			"image": modzy.S3Input(bucketName, fileKey),
 		},
 	}
@@ -145,7 +145,7 @@ func main() {
 			results.Results.Completed,
 			results.Results.Failed)
 		// Notice that we are iterating through the same input source keys
-		for key, _ := range mapSource {
+		for key := range mapSource {
 			// The result object has the individual results of each job input. In this case the output key is called
 			// results.json, so we can get the results as follows:
 			if result, exists := results.Results.Results[key]; exists {

--- a/samples/embedded_input/main.go
+++ b/samples/embedded_input/main.go
@@ -78,7 +78,7 @@ func main() {
 	// With the info about the model (identifier), the model version (version string, input/output keys), you are ready to
 	// submit the job. Just prepare the EmbeddedInputItem map:
 	mapSource := map[string]modzy.EmbeddedInputItem{
-		"source-key": modzy.EmbeddedInputItem{
+		"source-key": {
 			"input":       modzy.URIEncodeFile(imagePath, "image/png"),
 			"config.json": modzy.URIEncodeFile(configPath, "application/json"),
 		},

--- a/samples/file_input/main.go
+++ b/samples/file_input/main.go
@@ -45,7 +45,7 @@ func main() {
 	}
 	// You can find more information about how to query the models on the model_sample.go file.
 	// The model identifier is under the ModelID key. You can take a look at the other properties under ModelDetails struct
-	// Or just log the model identifier, and potencially the latest version
+	// Or just log the model identifier, and potentially the latest version
 	log.Printf("The model identifier is %s and the latest version is %s\n", model.Details.ModelID, model.Details.LatestVersion)
 	// Get the model version object:
 	// If you already know the model version and the input key(s) of the model version you can skip this step. Also, you can

--- a/samples/file_input/main.go
+++ b/samples/file_input/main.go
@@ -74,7 +74,7 @@ func main() {
 	imagePath := "./samples/image.png"
 	configPath := "./samples/config.json"
 	mapSource := map[string]modzy.FileInputItem{
-		"source-key": modzy.FileInputItem{
+		"source-key": {
 			"input":       modzy.FileInputFile(imagePath),
 			"config.json": modzy.FileInputFile(configPath),
 		},
@@ -143,7 +143,7 @@ func main() {
 			results.Results.Completed,
 			results.Results.Failed)
 		// Notice that we are iterating through the same input source keys
-		for key, _ := range mapSource {
+		for key := range mapSource {
 			// The result object has the individual results of each job input. In this case the output key is called
 			// results.json, so we can get the results as follows:
 			if result, exists := results.Results.Results[key]; exists {

--- a/samples/text_input/main.go
+++ b/samples/text_input/main.go
@@ -43,7 +43,7 @@ func main() {
 	}
 	// You can find more information about how to query the models on the model_sample.go file.
 	// The model identifier is under the ModelID key. You can take a look at the other properties under ModelDetails struct
-	// Or just log the model identifier, and potencially the latest version
+	// Or just log the model identifier, and potentially the latest version
 	log.Printf("The model identifier is %s and the latest version is %s\n", model.Details.ModelID, model.Details.LatestVersion)
 	// Get the model version object:
 	// If you already know the model version and the input key(s) of the model version you can skip this step. Also, you can

--- a/samples/text_input/main.go
+++ b/samples/text_input/main.go
@@ -16,7 +16,6 @@ func main() {
 	// The system admin can provide the right base API URL, the API key can be downloaded from your profile page on Modzy.
 	// You can configure those params as is described in the README file (as environment variables, or by using the .env file),
 	// or you can just update the BASE_URL and API_KEY variables and use this sample code (not recommended for production environments).
-	err := godotenv.Load()
 	if err := godotenv.Load(); err != nil {
 		log.Printf("NO .env file, will use current ENV\n")
 	}

--- a/samples/text_input/main.go
+++ b/samples/text_input/main.go
@@ -128,7 +128,7 @@ func main() {
 			results.Results.Completed,
 			results.Results.Failed)
 		// Notice that we are iterating through the same input source keys
-		for key, _ := range mapSource {
+		for key := range mapSource {
 			// The result object has the individual results of each job input. In this case the output key is called
 			// results.json, so we can get the results as follows:
 			if result, exists := results.Results.Results[key]; exists {


### PR DESCRIPTION
## Description

I added gloangci-lint as the `make lint` target;  This lints more thoroughly than staticcheck and also is the replacement for gometalinter.  This does not match up with goreportcard due to it using a deprecated linter (gometalinter). 

One real issue was found through this exercise - a misconfigured json tag.

I did not attempt to fix the many comment-related golint errors shown in goreportcard as these are due to the service using deprecated linters.

## Related issues

None

## Tests

## Checklist

- [x] I read the Contributing guide.
- [x] I update the documentation and if the case the README.md file.
- [x] I am willing to follow-up on review comments in a timely manner.
